### PR TITLE
Add marshal_for_signature method to EntryCommit.

### DIFF
--- a/factom_core/block_elements/chain_commit.py
+++ b/factom_core/block_elements/chain_commit.py
@@ -13,16 +13,30 @@ class ChainCommit:
     entry_hash: bytes
     ec_spent: int
     ec_public_key: bytes
-    signature: bytes
+    signature: bytes = None
 
     def __post_init__(self):
         # TODO: value assertions
         pass
 
+    def set_signature(self, signature: bytes):
+        assert isinstance(signature, bytes)
+        self.signature = signature
+
     def marshal(self):
         """Marshals the ChainCommit according to the byte-level representation shown at
         https://github.com/FactomProject/FactomDocs/blob/master/factomDataStructureDetails.md#chain-commit
         """
+        # Fail if signature is not set.
+        assert self.signature
+
+        buf = bytearray()
+        buf.extend(self.marshal_for_signature())
+        buf.extend(self.ec_public_key)
+        buf.extend(self.signature)
+        return bytes(buf)
+
+    def marshal_for_signature(self):
         buf = bytearray()
         buf.append(0x00)
         buf.extend(self.timestamp)
@@ -30,8 +44,6 @@ class ChainCommit:
         buf.extend(self.commit_weld)
         buf.extend(self.entry_hash)
         buf.append(self.ec_spent)
-        buf.extend(self.ec_public_key)
-        buf.extend(self.signature)
         return bytes(buf)
 
     @classmethod

--- a/factom_core/block_elements/chain_commit.py
+++ b/factom_core/block_elements/chain_commit.py
@@ -19,16 +19,12 @@ class ChainCommit:
         # TODO: value assertions
         pass
 
-    def set_signature(self, signature: bytes):
-        assert isinstance(signature, bytes)
-        self.signature = signature
-
     def marshal(self):
         """Marshals the ChainCommit according to the byte-level representation shown at
         https://github.com/FactomProject/FactomDocs/blob/master/factomDataStructureDetails.md#chain-commit
         """
         # Fail if signature is not set.
-        assert self.signature
+        assert self.signature is not None
 
         buf = bytearray()
         buf.extend(self.marshal_for_signature())

--- a/factom_core/block_elements/entry_commit.py
+++ b/factom_core/block_elements/entry_commit.py
@@ -17,10 +17,6 @@ class EntryCommit:
         # TODO: assert they're all here
         pass
 
-    def set_signature(self, signature: bytes):
-        assert isinstance(signature, bytes)
-        self.signature = signature
-
     def marshal(self):
         """Marshals the EntryCommit according to the byte-level representation shown at
         https://github.com/FactomProject/FactomDocs/blob/master/factomDataStructureDetails.md#entry-commit

--- a/factom_core/block_elements/entry_commit.py
+++ b/factom_core/block_elements/entry_commit.py
@@ -11,32 +11,25 @@ class EntryCommit:
     entry_hash: bytes
     ec_spent: int
     ec_public_key: bytes
-    _signature: bytes = None
+    signature: bytes = None
 
     def __post_init__(self):
         # TODO: assert they're all here
         pass
 
-    @property
-    def signature(self):
-        return self._signature
-
-    @signature.setter
-    def signature(self, signature: bytes):
-        self._signature = signature
+    def set_signature(self, signature: bytes):
+        assert isinstance(signature, bytes)
+        self.signature = signature
 
     def marshal(self):
         """Marshals the EntryCommit according to the byte-level representation shown at
         https://github.com/FactomProject/FactomDocs/blob/master/factomDataStructureDetails.md#entry-commit
         """
         # Fail if signature is not set.
-        assert self._signature is not None
+        assert self.signature is not None
 
         buf = bytearray()
-        buf.append(0x00)
-        buf.extend(self.timestamp)
-        buf.extend(self.entry_hash)
-        buf.append(self.ec_spent)
+        buf.extend(self.marshal_for_signature())
         buf.extend(self.ec_public_key)
         buf.extend(self.signature)
         return bytes(buf)

--- a/factom_core/block_elements/entry_commit.py
+++ b/factom_core/block_elements/entry_commit.py
@@ -11,16 +11,27 @@ class EntryCommit:
     entry_hash: bytes
     ec_spent: int
     ec_public_key: bytes
-    signature: bytes
+    _signature: bytes = None
 
     def __post_init__(self):
         # TODO: assert they're all here
         pass
 
+    @property
+    def signature(self):
+        return self._signature
+
+    @signature.setter
+    def signature(self, signature: bytes):
+        self._signature = signature
+
     def marshal(self):
         """Marshals the EntryCommit according to the byte-level representation shown at
         https://github.com/FactomProject/FactomDocs/blob/master/factomDataStructureDetails.md#entry-commit
         """
+        # Fail if signature is not set.
+        assert self._signature is not None
+
         buf = bytearray()
         buf.append(0x00)
         buf.extend(self.timestamp)
@@ -28,6 +39,14 @@ class EntryCommit:
         buf.append(self.ec_spent)
         buf.extend(self.ec_public_key)
         buf.extend(self.signature)
+        return bytes(buf)
+
+    def marshal_for_signature(self):
+        buf = bytearray()
+        buf.append(0x00)
+        buf.extend(self.timestamp)
+        buf.extend(self.entry_hash)
+        buf.append(self.ec_spent)
         return bytes(buf)
 
     @classmethod


### PR DESCRIPTION
I only implemented the change for EntryCommit. Once you're happy with it I'll do the same for ChainCommit since it will be very similar. The only thing that is a bit janky is I had to make the `signature` property private in the dataclass initialization in order to allow it to be set to None by default. Working with properties and dataclasses is a bit trickier than I thought. I wanted to be able to allow a developer to instantiate the class in one line if they already had the signature they needed

`entry_commit = EntryCommit(..., signature)`

though that's probably not a common use case and using `marshal_for_signature()` will probably be they way most people use this.  If you don't like this some other approaches are:

Don't use `@property` and define a `set_signature()` method (and a `get_signature()` method?). 

Use `@property` keep `signature` public in the initialization but set the default signature value to `b"0"` and check for that value instead of None.
